### PR TITLE
Pin Web Driver Chrome via postinstall script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,4 +14,5 @@ jobs:
       - run: npm install
       - run: npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
       - run: npm run lint
+      - run: npm run postinstall
       - run: npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "ng build",
     "test": "ng test",
     "test:single": "ng test -- --watch=false --browsers=ChromeHeadlessCI",
+    "postinstall": "webdriver-manager update --versions.chrome 89.0.4389.114 --gecko=false",
     "lint": "ng lint ngTicTacToe",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e -- --webdriver-update=false"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This seems to be the thing people do, since otherwise Webdriver kinda does its own thing.

Also, specify no update when we run the tests themselves

This was helpful: https://satantime.github.io/puppeteer-node/

Note as well that the unit tests still grab a more recent version of Chrome (which is fine, since they don't stop running all the time)