### PR TITLE
Split push checks into different jobs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "16"
       - run: npm install
       - run: npm run lint
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "16"
       - run: npm install
       - run: npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
 
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
+          node-version: "16"
       - run: npm install
       - run: npm run postinstall
       - run: npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,8 +3,19 @@ on:
   - push
 
 jobs:
-  run_tests:
-    name: "Run tests"
+  run_lint:
+    name: "Run lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+      - run: npm install
+      - run: npm run lint
+
+  run_unit:
+    name: "Run unit tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,6 +24,15 @@ jobs:
           node-version: "12"
       - run: npm install
       - run: npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
-      - run: npm run lint
+
+  run_tests:
+    name: "Run e2e tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12"
+      - run: npm install
       - run: npm run postinstall
       - run: npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,8 @@
 name: "Push checks"
 on:
-  - push
+  push:
+  schedule:
+    - cron: "0 4 * * 6"
 
 jobs:
   run_lint:


### PR DESCRIPTION
The idea here is that we'll get full feedback when needed - e.g. still know where we stand with e2e tests if lint fails.

Also, update to most recent version of node, since our older version on the way out, and getting us a bit ahead of the curve.