### PR TITLE
Fix flaky test & debug improvements

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "msjsdiag.debugger-for-chrome"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test",
+    "test": "ng test --browsers=ChromeDebugging",
     "test:single": "ng test -- --watch=false --browsers=ChromeHeadlessCI",
     "postinstall": "webdriver-manager update --versions.chrome 89.0.4389.114 --gecko=false",
     "lint": "ng lint ngTicTacToe",

--- a/src/app/game-status-dashboard/game-status-dashboard.component.spec.ts
+++ b/src/app/game-status-dashboard/game-status-dashboard.component.spec.ts
@@ -21,6 +21,7 @@ describe('GameStatusDashboardComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(GameStatusDashboardComponent);
     component = fixture.componentInstance;
+    gameServiceMock.reset();
     fixture.detectChanges();
   });
 

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -10,28 +10,32 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
-      require('@angular-devkit/build-angular/plugins/karma')
+      require('@angular-devkit/build-angular/plugins/karma'),
     ],
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../coverage'),
       reports: ['html', 'lcovonly'],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'ChromeDebugging'],
     customLaunchers: {
       ChromeHeadlessCI: {
         base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--disable-gpu']
-      }
+        flags: ['--no-sandbox', '--disable-gpu'],
+      },
+      ChromeDebugging: {
+        base: 'Chrome',
+        flags: ['--remote-debugging-port=9222'],
+      },
     },
-    singleRun: false
+    singleRun: false,
   });
 };

--- a/src/testing/game-service.stub.ts
+++ b/src/testing/game-service.stub.ts
@@ -11,6 +11,8 @@ export class GameServiceStub {
         return 3;
     }
 
+    reset() { this.active = true; }
+
     get hasGameEnded() { return !this.active; }
 
     toggleGameActive() { this.active = !this.active; }


### PR DESCRIPTION
Fix a test that was flaky due to mock state not being reset between tests:
![image](https://user-images.githubusercontent.com/2937540/115955393-279bcf80-a4c4-11eb-844d-1d8d1d9968b6.png)


(also seen [here](https://github.com/AndrewADev/ng-tic-tac-toe/runs/2415031650?check_suite_focus=true))

Also add a few tiny improvements to debugging made along the way:
- Add a plugins recommendation file, to give hints on how the project is developed
- Add missing Karma config so that we can actually attach to the Karma-launched browser via our debug config in `launch.json`