### PR TITLE
Split lint and tests into separate workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,7 @@ jobs:
   run_lint:
     name: "Run lint"
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,10 @@
 name: "Push checks"
 on:
   push:
-  schedule:
-    - cron: "0 4 * * 6"
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   run_lint:
@@ -15,26 +17,3 @@ jobs:
           node-version: "16"
       - run: npm install
       - run: npm run lint
-
-  run_unit:
-    name: "Run unit tests"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      - run: npm install
-      - run: npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
-
-  run_tests:
-    name: "Run e2e tests"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      - run: npm install
-      - run: npm run postinstall
-      - run: npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,35 @@
+name: "Tests"
+on:
+  # Manual trigger, in case want one-off run on a working branch
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**"
+      - "e2e/**"
+      - "!e2e/.eslintrc.json"
+      - "package.json"
+      - "package-lock.json"
+
+jobs:
+  run_unit:
+    name: "Run unit tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - run: npm install
+      - run: npm run test -- --watch=false --progress=false --browsers=ChromeHeadlessCI
+
+  run_tests:
+    name: "Run e2e tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - run: npm install
+      - run: npm run postinstall
+      - run: npm run e2e -- --protractor-config=./e2e/protractor-ci.conf.js

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,7 @@ jobs:
   run_unit:
     name: "Run unit tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -25,6 +26,7 @@ jobs:
   run_tests:
     name: "Run e2e tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Split the two sets of jobs into separate workflows.

Lint we will now run on push to source files, and package file (in case lint command itself is updated or plugins updated, new ones added, etc).

The tests we now run primarily for pull requests, though I'm adding a manual trigger in case we want to run them on demand for a working branch (compare local with CI behavior, say). From what I can tell, this [should be available on branches too](https://github.community/t/workflow-dispatch-event-not-working/128856/2), once it has been triggered, or is on main branch.